### PR TITLE
Tentative fix for BENTO-2211

### DIFF
--- a/src/components/navBar/NavBarView.js
+++ b/src/components/navBar/NavBarView.js
@@ -44,11 +44,6 @@ const NavBar = ({
       default:
         return (
           <span className={classes.badge}>
-            <img
-              className={classes.cartIcon}
-              src={navBarCartData.cartIcon}
-              alt={navBarCartData.cartIconAlt}
-            />
             <span className={classes.cartCounter}>
               {numberOfCases}
             </span>
@@ -116,17 +111,11 @@ const NavBar = ({
                 {/* <Badge badgeContent={numberOfCases} max={99999}> */}
                 <Tooltip title="Files" placement="bottom-end">
                   <span className={classes.badge}>
-                    {/**
-                     * Joon Lee, BENTO-2211 - I suspect that the <img>
-                     * element below causes two cart icons to apear,
-                     * because the getCartLabel() function already
-                     * creates a cart icon
-                     */
-                    /* <img
+                    <img
                       className={classes.cartIcon}
                       src={navBarCartData.cartIcon}
                       alt={navBarCartData.cartIconAlt}
-                    /> */}
+                    />
                     {getCartLabel(cartLabelType)}
                   </span>
                 </Tooltip>

--- a/src/components/navBar/NavBarView.js
+++ b/src/components/navBar/NavBarView.js
@@ -116,11 +116,17 @@ const NavBar = ({
                 {/* <Badge badgeContent={numberOfCases} max={99999}> */}
                 <Tooltip title="Files" placement="bottom-end">
                   <span className={classes.badge}>
-                    <img
+                    {/**
+                     * Joon Lee, BENTO-2211 - I suspect that the <img>
+                     * element below causes two cart icons to apear,
+                     * because the getCartLabel() function already
+                     * creates a cart icon
+                     */
+                    /* <img
                       className={classes.cartIcon}
                       src={navBarCartData.cartIcon}
                       alt={navBarCartData.cartIconAlt}
-                    />
+                    /> */}
                     {getCartLabel(cartLabelType)}
                   </span>
                 </Tooltip>
@@ -227,7 +233,7 @@ const styles = () => ({
     textAlign: 'start',
     fontSize: '12px',
   },
-  cartLabel:(props) => ({
+  cartLabel: (props) => ({
     height: '16px',
     minWidth: '16px',
     color: props.navBarstyling.cartLabel && props.navBarstyling.cartLabel.color ? props.navBarstyling.cartLabel.color : '#24E4BE',


### PR DESCRIPTION
Should fix issue with double cart icons showing up in Bento-based projects that use this library's NavBar component. Haven't been able to test this locally.